### PR TITLE
Intersection observer added that prevent the load slide images.

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack-dev-server": "^3.1.5"
   },
   "dependencies": {
+    "@researchgate/react-intersection-observer": "^0.7.4",
     "autobind-decorator": "^2.1.0",
     "babel-plugin-syntax-dynamic-import": "^6.18.0",
     "clean-webpack-plugin": "^1.0.0",
@@ -69,8 +70,8 @@
     "react-router": "^4.3.1",
     "react-router-dom": "^4.3.1",
     "sass-extract": "^2.1.0",
-    "sass-extract-loader": "^1.1.0",
     "sass-extract-js": "^0.4.0",
+    "sass-extract-loader": "^1.1.0",
     "styled-components": "^4.1.3",
     "stylelint-webpack-plugin": "^0.10.5",
     "svg-inline-loader": "^0.8.0",

--- a/src/js/components/card/card.js
+++ b/src/js/components/card/card.js
@@ -13,7 +13,7 @@ const Card = ({ item, isActive }) => (
   // Should keep the className for animation.
   <Slide className={`slide ${isActive}`}>
     <Wrapper>
-      <Image image={item.urls.regular} data-purpose="card-img" />
+      <Image image={item.urls} />
       <Content data-color={item.color} data-purpose="card-content">
         <Tag>{item.tags[0] && item.tags[0].title}</Tag>
         <Title>{item.user.name}</Title>

--- a/src/js/components/card/elements/image.js
+++ b/src/js/components/card/elements/image.js
@@ -1,16 +1,61 @@
 import styled from 'styled-components';
+import React, { Component } from 'react';
+import Observer from '@researchgate/react-intersection-observer';
+import PropTypes from 'prop-types';
 
-const Image = styled.div`
-    background-position: center;
+const Placeholder = styled.div`
+    overflow: hidden;
     width: 50%;
     height: 100%;
-    background-size: cover;
-    background-repeat: no-repeat;
-    background-image: url(${props => props.image});
     @media only screen and (max-width: 768px) {
         width: 100%;
         height: 55%;
     }
 `;
 
-export default Image;
+const StyledImage = styled.div`
+    background-position: center;
+    object-fit: cover;
+    width: 100%;
+    height: 100%;
+    background-size: cover;
+    background-repeat: no-repeat;
+    background-image: url(${props => props.image});
+`;
+
+export default class Image extends Component {
+  constructor(props) {
+    super(props);
+    this.handleIntersection = this.handleIntersection.bind(this);
+    this.state = {
+      showImage: false,
+    };
+  }
+
+  handleIntersection({ isIntersecting }, unobserve) {
+    // First two images will load.
+    if (isIntersecting) {
+      unobserve();
+    }
+    this.setState({
+      showImage: isIntersecting,
+    });
+  }
+
+  render() {
+    return (
+      <Observer onChange={this.handleIntersection}>
+        <Placeholder className="placeholder">
+          {
+            this.state.showImage
+              && <StyledImage image={this.props.image.regular} data-purpose="card-img" />
+            }
+        </Placeholder>
+      </Observer>
+    );
+  }
+}
+
+Image.propTypes = {
+  image: PropTypes.object.isRequired,
+};


### PR DESCRIPTION
Issue: https://github.com/hamzaerbay/react-content-slider/issues/4

It has added intersection observer that prevent the offscreen slide image loading.
 **Before**
<img width="721" alt="screen shot 2019-02-17 at 5 58 36 pm" src="https://user-images.githubusercontent.com/5136093/52923661-b48fe080-32dd-11e9-9b48-7e3545c6d37d.png">
**After**
<img width="721" alt="screen shot 2019-02-17 at 5 58 05 pm" src="https://user-images.githubusercontent.com/5136093/52923672-be194880-32dd-11e9-98c0-6d5f263d8cf5.png">
