### PR TITLE
Intersection observer polyfill added

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "enzyme-adapter-react-16": "^1.1.1",
     "gsap": "^2.0.2",
     "html-webpack-plugin": "^3.2.0",
+    "intersection-observer": "^0.5.1",
     "jquery": "^3.3.1",
     "mini-css-extract-plugin": "^0.4.1",
     "mobx": "^5.0.3",

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ import { ThemeProvider } from 'styled-components';
 import themeVariables from 'sass-extract-loader?{"plugins": ["sass-extract-js"]}!./sass/variables.scss';
 import CardSlider from './js/card-slider';
 import './sass/style.scss';
+import 'intersection-observer';
 
 const App = () => (
   <ThemeProvider theme={themeVariables}>


### PR DESCRIPTION
https://github.com/researchgate/react-intersection-observer doesn't support by the older browser. So we need a polyfill for that.